### PR TITLE
Update postcss loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "mkpath": "^1.0.0",
     "morgan": "1.7.0",
     "object-assign": "^4.1.1",
-    "postcss-loader": "^1.3.3",
+    "postcss-loader": "2.0.6",
     "raw-loader": "^0.5.1",
     "react": "15.4.2",
     "react-bootstrap": "0.30.7",


### PR DESCRIPTION
It's because postcss-nested package needs postcss > 2.